### PR TITLE
Explicit support for `honister`, `dunfell`, `kirkstone`, `mickledore `

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,10 @@ jobs:
       matrix:
         # Yocto versions (using branch convention)
         # https://wiki.yoctoproject.org/wiki/Releases
-        branch: [
-          "langdale",
-          "kirkstone",
-          "honister",
-          "hardknott",
-          "gatesgarth",
-          "dunfell",
-        ]
+        branch: ["mickledore", "kirkstone", "honister", "dunfell"]
     env:
       YOCTO_RELEASE: ${{ matrix.branch }}
-    
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install Host dependencies
@@ -29,11 +22,12 @@ jobs:
           xz-utils debianutils iputils-ping python3-git python3-jinja2 \
           libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit \
           mesa-common-dev zstd liblz4-tool
-          
+
       - name: Check out meta-fossa
         uses: actions/checkout@v3
-        
+
       - name: Run Yocto check layer script
+        if: github.ref == 'refs/heads/${{ matrix.branch }}'
         run: |
           cd ${RUNNER_TEMP}
           git clone --depth 1 --branch ${YOCTO_RELEASE} https://git.yoctoproject.org/git/poky 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         # Yocto versions (using branch convention)
         # https://wiki.yoctoproject.org/wiki/Releases
-        branch: ["mickledore", "kirkstone", "honister", "dunfell"]
+        branch: ["dunfell"]
     env:
       YOCTO_RELEASE: ${{ matrix.branch }}
 
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Yocto check layer script
-        if: github.ref == 'refs/heads/${{ matrix.branch }}'
         run: |
           cd ${RUNNER_TEMP}
           git clone --depth 1 --branch ${YOCTO_RELEASE} https://git.yoctoproject.org/git/poky 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@
 
 _For more details and configuration options, please refer to our [integration guide](./GUIDE.md)!_
 
+| Yocto Version | meta-fossa branch                                                                 |
+| ------------- | --------------------------------------------------------------------------------- |
+| `dunfell`     | `dunfell` or `master`                                                             |
+| `honister`    | `honister` ([honister](https://github.com/fossas/meta-fossa/tree/honister))       |
+| `kirkstone`   | `kirkstone` ([kirkstone](https://github.com/fossas/meta-fossa/tree/kirkstone))    |
+| `mickledore`  | `mickledore` ([mickledore](https://github.com/fossas/meta-fossa/tree/mickledore)) |
+
 ```shell
 # Check out the FOSSA layer.
-; git clone git@github.com:fossas/meta-fossa.git
+; git clone https://github.com/fossas/meta-fossa.git -b dunfell
 
 # Check out Yocto, if it isn't already.
 ; git clone git://git.yoctoproject.org/poky.git -b dunfell

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 _For more details and configuration options, please refer to our [integration guide](./GUIDE.md)!_
 
-| Yocto Version | meta-fossa branch                                                                 |
-| ------------- | --------------------------------------------------------------------------------- |
-| `dunfell`     | `dunfell` or `master`                                                             |
-| `honister`    | `honister` ([honister](https://github.com/fossas/meta-fossa/tree/honister))       |
-| `kirkstone`   | `kirkstone` ([kirkstone](https://github.com/fossas/meta-fossa/tree/kirkstone))    |
-| `mickledore`  | `mickledore` ([mickledore](https://github.com/fossas/meta-fossa/tree/mickledore)) |
+| Yocto Version | meta-fossa branch                                                  |
+| ------------- | ------------------------------------------------------------------ |
+| `dunfell`     | [`dunfell`](https://github.com/fossas/meta-fossa/tree/honister)    |
+| `honister`    | [honister](https://github.com/fossas/meta-fossa/tree/honister)     |
+| `kirkstone`   | [kirkstone](https://github.com/fossas/meta-fossa/tree/kirkstone)   |
+| `mickledore`  | [mickledore](https://github.com/fossas/meta-fossa/tree/mickledore) |
 
 ```shell
 # Check out the FOSSA layer.


### PR DESCRIPTION
# Overview

This PR, 

- Updates doc for `dunfell` (current LTS), `honister`  (3.4.x), `kirkstone` (4.0.x), `mickledore` (4.2.x)
- Follows bitbake convention (branch-name of layer targets branch-name of poky)
- Updates CI
- Updates `fossa-cli` to latest version (not for dunfell)
- Updates recipe, so we are not dependent on `install-latest.sh` script (since, we need to explicitly build, wget, awk || curl, sed) for future compatibility

## Acceptance criteria

- meta-fossa supports `honister`
- meta-fossa supports `kirkstone`
- meta-fossa supports `mickledore`

## Review

- kirkstone: https://github.com/fossas/meta-fossa/compare/kirkstone?diff=unified
- mickledore: https://github.com/fossas/meta-fossa/compare/mickledore?diff=unified
- honister: https://github.com/fossas/meta-fossa/compare/honister?diff=unified
- dunfell: https://github.com/fossas/meta-fossa/compare/dunfell?diff=unified


## Testing plan

Go to each branch, follow setup guide, and perform fossa upload and test successfully. 

- [ ] `dunfell` works
- [ ] `honister` works
- [ ] `kirkstone` works
- [ ] `mickledore` works

Since, yocto builds are quite extensive - I recommend spinning up ~48 core ec2 with tons of memory and storage. 

## Risks

N/A

## References

https://fossa.atlassian.net/browse/PS-236

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I have updated relevant documentation.
